### PR TITLE
fix search card api

### DIFF
--- a/handler/card.go
+++ b/handler/card.go
@@ -153,5 +153,9 @@ func (h CardHandler) SearchCard(c *gin.Context) {
 
 	ids := h.repository.Search(p.BoardID, currentUserID(c), p.Title)
 
+	if len(ids) == 0 {
+		ids = make([]uint, 0)
+	}
+
 	c.JSON(http.StatusOK, gin.H{"card_ids": ids})
 }

--- a/repository/card.go
+++ b/repository/card.go
@@ -144,7 +144,7 @@ func (r *CardRepository) Delete(c *entity.Card) []validator.ValidationError {
 }
 
 // Search returns instances of Card that found by Card's title.
-func (r *CardRepository) Search(bid, uid uint, title string) *[]uint {
+func (r *CardRepository) Search(bid, uid uint, title string) []uint {
 	var ids []uint
 
 	r.db.Model(&entity.Card{}).
@@ -153,8 +153,9 @@ func (r *CardRepository) Search(bid, uid uint, title string) *[]uint {
 		Where("boards.user_id = ?", uid).
 		Where("boards.id = ?", bid).
 		Where("cards.title LIKE ?", "%"+title+"%").
+		Where("lists.deleted_at IS NULL").
 		Order("cards.list_id asc").
 		Pluck("cards.id", &ids)
 
-	return &ids
+	return ids
 }

--- a/repository/card_test.go
+++ b/repository/card_test.go
@@ -458,7 +458,7 @@ func TestShouldSuccessfullySearchCard(t *testing.T) {
 		t.Fatalf("there were unfulfilled expectations: %v", err)
 	}
 
-	for _, c := range *cs {
+	for _, c := range cs {
 		assert.Equal(t, c, cardID)
 	}
 }


### PR DESCRIPTION
## What

- カードの検索SQLに`lists.deleted_at IS NULL`を追加
- 該当レコードが0件の場合、レスポンスで`Null`を返す問題の修正